### PR TITLE
fix(command-input): continuation lines after leading tabs; align paste prefix check

### DIFF
--- a/src/cm/extensions/CommandInputExtension.ts
+++ b/src/cm/extensions/CommandInputExtension.ts
@@ -96,6 +96,8 @@ function createInputExtension(plugin: StewardPlugin, options: CommandInputOption
         const decorations = [];
         let extendedPrefixes: string[] | null = null;
         let modelLabel: string | undefined;
+        // Track if we fetched data asynchronously (e.g., model label from conversation title)
+        // so we can trigger a view update after decorations are set
         let isAsync = false;
 
         // Get visible range instead of processing the entire document
@@ -130,6 +132,7 @@ function createInputExtension(plugin: StewardPlugin, options: CommandInputOption
                   conversationTitle,
                   forceRefresh: true,
                 });
+                // Mark that we performed an async operation (await above)
                 isAsync = true;
               } else {
                 const commandName = matchedPrefix.replace('/', '').trim();
@@ -196,6 +199,8 @@ function createInputExtension(plugin: StewardPlugin, options: CommandInputOption
 
         this.decorations = Decoration.set(decorations);
 
+        // If we performed async operations, dispatch an empty transaction to trigger
+        // a view update and re-render the decorations with the fetched data
         if (isAsync) {
           setTimeout(() => {
             this.view.dispatch({});
@@ -267,11 +272,9 @@ function createPasteHandlerExtension(plugin: StewardPlugin): Extension {
         const line = view.state.doc.lineAt(from);
 
         // Check if we're in a command input context
-        const isInCommandContext =
-          plugin.commandInputService.isCommandLine(line) ||
-          plugin.commandInputService.isContinuationLine(line.text);
+        const inputPrefix = plugin.commandInputService.getInputPrefix(line, view.state.doc);
 
-        if (!isInCommandContext) {
+        if (!inputPrefix) {
           return false; // Let default paste behavior happen
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,6 @@ import {
   SEARCH_DB_NAME_PREFIX,
   SMILE_CHAT_ICON_ID,
   STW_CHAT_VIEW_CONFIG,
-  TWO_SPACES_PREFIX,
 } from './constants';
 import { StewardChatView } from './views/StewardChatView';
 import { Events } from './types/events';
@@ -744,7 +743,10 @@ export default class StewardPlugin extends Plugin {
         const prevLine = doc.line(currentLineNum);
 
         // If we find a non-continuation line that's not a command, break
-        if (!prevLine.text.startsWith(TWO_SPACES_PREFIX) && !prevLine.text.startsWith('/')) {
+        if (
+          !this.commandInputService.isContinuationLine(prevLine.text) &&
+          !prevLine.text.startsWith('/')
+        ) {
           break;
         }
 

--- a/src/services/CommandInputService.ts
+++ b/src/services/CommandInputService.ts
@@ -5,6 +5,7 @@ import { MarkdownUtil } from 'src/utils/markdownUtils';
 import type StewardPlugin from 'src/main';
 import { StewardChatView } from 'src/views/StewardChatView';
 import { logger } from 'src/utils/logger';
+import { TWO_SPACES_PREFIX } from 'src/constants';
 
 /**
  * Service for handling command input operations in the editor
@@ -268,7 +269,15 @@ export class CommandInputService {
   }
 
   public isContinuationLine(text: string): boolean {
-    return text.startsWith('  ') && !text.startsWith('   ');
+    let start = 0;
+    for (; start < text.length; start++) {
+      if (text.charAt(start) !== '\t') break;
+    }
+    const withoutLeadingTabs = text.slice(start);
+    return (
+      withoutLeadingTabs.startsWith(TWO_SPACES_PREFIX) &&
+      !withoutLeadingTabs.startsWith('   ')
+    );
   }
 
   public isGeneralCommandLine(line: Line): boolean {
@@ -297,7 +306,7 @@ export class CommandInputService {
         const prevLine = doc.line(currentLineNum);
 
         // If we find a non-continuation line that's not a command, break
-        if (!prevLine.text.startsWith('  ') && !prevLine.text.startsWith('/')) {
+        if (!this.isContinuationLine(prevLine.text) && !prevLine.text.startsWith('/')) {
           break;
         }
 

--- a/src/services/CommandInputService.ts
+++ b/src/services/CommandInputService.ts
@@ -275,8 +275,7 @@ export class CommandInputService {
     }
     const withoutLeadingTabs = text.slice(start);
     return (
-      withoutLeadingTabs.startsWith(TWO_SPACES_PREFIX) &&
-      !withoutLeadingTabs.startsWith('   ')
+      withoutLeadingTabs.startsWith(TWO_SPACES_PREFIX) && !withoutLeadingTabs.startsWith('   ')
     );
   }
 


### PR DESCRIPTION
Use getInputPrefix for paste context; 
isContinuationLine strips leading tabs before TWO_SPACES_PREFIX.