### PR TITLE
2.8.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,31 +7,42 @@ on:
 
 jobs:
   build:
+    name: Create Release and Attest Assets
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: write
+      attestations: write
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20.x'
           cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Install dependencies and build
+        run: |
+          npm ci
+          npm run build
 
-      - name: Build plugin
-        run: npm run build
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
 
       - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: |
+            main.js
+            manifest.json
+            styles.css
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          tag="${GITHUB_REF#refs/tags/}"
-
-          gh release create "$tag" \
-            --title="$tag" \
-            --draft \
-            main.js manifest.json styles.css

--- a/internal/bundled-internals-entry.ts
+++ b/internal/bundled-internals-entry.ts
@@ -1,6 +1,6 @@
 /**
  * First-party modules bundled by `scripts/build-bundled-libs.mjs`, LZ-compressed to Base64,
- * and evaluated from `src/utils/bundledInternals.ts` so `main.js` does not parse them at startup.
+ * and loaded from `src/utils/bundledInternals.ts` so `main.js` does not parse them at startup.
  *
  * Add more namespaces (services, solutions, …) here as they move into this payload.
  */

--- a/src/utils/bundledChunkRuntime.ts
+++ b/src/utils/bundledChunkRuntime.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared runtime for decompressed bundled chunks.
+ */
+
+type GlobalWithChunks = typeof globalThis & Record<string, unknown>;
+
+function getBundledChunkGlobal(): GlobalWithChunks {
+  if (typeof window !== 'undefined') {
+    return window as unknown as GlobalWithChunks;
+  }
+  return globalThis as unknown as GlobalWithChunks;
+}
+
+/**
+ * @param pluginRequire  Pass the plugin's local `require` when the chunk contains
+ *   external modules resolved by Obsidian's loader (e.g. `"obsidian"`).
+ *   The global `window.require` is Electron's native one and cannot resolve them.
+ */
+export function runBundledChunk(code: string, context: string, pluginRequire?: NodeRequire): void {
+  const g = getBundledChunkGlobal();
+  const savedRequire = g['require'];
+  try {
+    if (pluginRequire) {
+      g['require'] = pluginRequire;
+    }
+    g.eval.call(g, code);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(`[Steward] Failed to execute bundled chunk (${context}): ${msg}`);
+  } finally {
+    if (pluginRequire) {
+      g['require'] = savedRequire;
+    }
+  }
+}
+
+export function readBundledChunkGlobal<T>(key: string, context: string): T {
+  const g = getBundledChunkGlobal();
+  const raw = g[key] as T | undefined;
+  if (!raw) {
+    throw new Error(`[Steward] Bundled chunk did not define ${key} (${context})`);
+  }
+  return raw;
+}
+
+export function unwrapBundledRegistry<T extends object>(raw: unknown): T {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error('[Steward] Bundled registry is missing or invalid');
+  }
+  const d = (raw as { default?: unknown }).default;
+  if (d !== undefined && d !== null && typeof d === 'object') {
+    return d as T;
+  }
+  return raw as T;
+}

--- a/src/utils/bundledInternals.ts
+++ b/src/utils/bundledInternals.ts
@@ -1,6 +1,11 @@
 import { decompressFromBase64 } from 'lz-string';
 import type { BundledInternals } from '../../internal/bundled-internals-entry';
 import { BUNDLED_INTERNALS_LZ_B64 } from '../generated/bundledInternalsPayload';
+import {
+  readBundledChunkGlobal,
+  runBundledChunk,
+  unwrapBundledRegistry,
+} from './bundledChunkRuntime';
 
 type BundledInternalsRegistry = {
   [K in keyof BundledInternals]: BundledInternals[K];
@@ -8,48 +13,24 @@ type BundledInternalsRegistry = {
 
 let registry: BundledInternalsRegistry | null = null;
 
-function unwrapBundledRegistry<T extends object>(raw: unknown): T {
-  if (!raw || typeof raw !== 'object') {
-    throw new Error('[Steward] Bundled internals registry is missing or invalid');
-  }
-  const d = (raw as { default?: unknown }).default;
-  if (d !== undefined && d !== null && typeof d === 'object') {
-    return d as T;
-  }
-  return raw as T;
-}
-
 /**
  * Decompresses and evaluates the internals chunk once. Synchronous so plugin getters can stay sync.
  */
 export function ensureBundledInternalsLoadedSync(): BundledInternalsRegistry {
-  if (!registry) {
-    const t0 = performance.now();
-    const code = decompressFromBase64(BUNDLED_INTERNALS_LZ_B64);
-    const decompressMs = performance.now() - t0;
-    if (!code) {
-      throw new Error('[Steward] Failed to decompress bundled internals payload');
-    }
-    const runChunk = new Function(
-      'require',
-      `${code}
-return __stewardBundledInternals;`
-    );
-    const t1 = performance.now();
-    const raw = runChunk(require);
-    const evalMs = performance.now() - t1;
-    const totalMs = performance.now() - t0;
-    if (!raw) {
-      throw new Error('[Steward] Bundled internals chunk did not produce a registry');
-    }
-    registry = unwrapBundledRegistry<BundledInternalsRegistry>(raw);
-    console.info('[Steward] Bundled internals timing (first load)', {
-      decompressMs: Number(decompressMs.toFixed(2)),
-      parseEvalMs: Number(evalMs.toFixed(2)),
-      totalMs: Number(totalMs.toFixed(2)),
-      source: 'ensureBundledInternalsLoadedSync',
-    });
+  if (registry) {
+    return registry;
   }
+
+  const code = decompressFromBase64(BUNDLED_INTERNALS_LZ_B64);
+  if (!code) {
+    throw new Error('[Steward] Failed to decompress bundled internals payload');
+  }
+
+  runBundledChunk(code, 'bundled-internals', require);
+  const raw = readBundledChunkGlobal<unknown>('__stewardBundledInternals', 'bundled-internals');
+
+  registry = unwrapBundledRegistry<BundledInternalsRegistry>(raw);
+
   return registry;
 }
 

--- a/src/utils/bundledLibs.ts
+++ b/src/utils/bundledLibs.ts
@@ -5,30 +5,11 @@ import { BUNDLED_SYNC_LIBS_LZ_B64 } from '../generated/bundledSyncLibsPayload';
 import type { BundledLibs } from 'src/bundled-libs-entry';
 import type { BundledDesktopLibs } from 'src/bundled-libs-desktop-entry';
 import type { BundledSyncLibs } from 'src/bundled-libs-sync-entry';
-
-/**
- * esbuild IIFE + `export default` yields an interop object on the global object:
- * `{ __esModule: true, default: <actual registry> }`.
- *
- * Prefer `window` when it exists (Obsidian renderer / popouts); use `globalThis` in Node/Jest.
- */
-function bundledChunkGlobal(): typeof globalThis {
-  if (typeof window !== 'undefined') {
-    return window as typeof globalThis;
-  }
-  return globalThis;
-}
-
-function unwrapBundledRegistry<T extends object>(raw: unknown): T {
-  if (!raw || typeof raw !== 'object') {
-    throw new Error('[Steward] Bundled registry is missing or invalid');
-  }
-  const d = (raw as { default?: unknown }).default;
-  if (d !== undefined && d !== null && typeof d === 'object') {
-    return d as T;
-  }
-  return raw as T;
-}
+import {
+  readBundledChunkGlobal,
+  runBundledChunk,
+  unwrapBundledRegistry,
+} from './bundledChunkRuntime';
 
 type BundledLibKey = keyof BundledLibs;
 
@@ -43,12 +24,8 @@ function ensureBundledLibsRegistryLoaded(): Promise<BundledLibsRegistry> {
       if (!code) {
         throw new Error('[Steward] Failed to decompress bundled libs payload');
       }
-      (0, eval)(code);
-      const raw = (bundledChunkGlobal() as unknown as { __stewardBundledLibs?: unknown })
-        .__stewardBundledLibs;
-      if (!raw) {
-        throw new Error('[Steward] Bundled libs chunk did not define __stewardBundledLibs');
-      }
+      runBundledChunk(code, 'bundled-libs');
+      const raw = readBundledChunkGlobal<unknown>('__stewardBundledLibs', 'bundled-libs');
       return unwrapBundledRegistry<BundledLibsRegistry>(raw);
     })();
   }
@@ -71,14 +48,11 @@ function ensureBundledDesktopLibsRegistryLoaded(): Promise<BundledDesktopLibsReg
       if (!code) {
         throw new Error('[Steward] Failed to decompress bundled desktop libs payload');
       }
-      (0, eval)(code);
-      const raw = (bundledChunkGlobal() as unknown as { __stewardBundledDesktopLibs?: unknown })
-        .__stewardBundledDesktopLibs;
-      if (!raw) {
-        throw new Error(
-          '[Steward] Bundled desktop libs chunk did not define __stewardBundledDesktopLibs'
-        );
-      }
+      runBundledChunk(code, 'bundled-desktop-libs');
+      const raw = readBundledChunkGlobal<unknown>(
+        '__stewardBundledDesktopLibs',
+        'bundled-desktop-libs'
+      );
       return unwrapBundledRegistry<BundledDesktopLibsRegistry>(raw);
     })();
   }
@@ -101,12 +75,8 @@ function ensureBundledSyncLibsRegistryLoadedSync(): BundledSyncLibsRegistry {
     throw new Error('[Steward] Failed to decompress bundled sync libs payload');
   }
 
-  (0, eval)(code);
-  const raw = (bundledChunkGlobal() as unknown as { __stewardBundledSyncLibs?: unknown })
-    .__stewardBundledSyncLibs;
-  if (!raw) {
-    throw new Error('[Steward] Bundled sync libs chunk did not define __stewardBundledSyncLibs');
-  }
+  runBundledChunk(code, 'bundled-sync-libs');
+  const raw = readBundledChunkGlobal<unknown>('__stewardBundledSyncLibs', 'bundled-sync-libs');
 
   syncRegistry = unwrapBundledRegistry<BundledSyncLibsRegistry>(raw);
   return syncRegistry;
@@ -126,7 +96,7 @@ export async function getBundledLib<K extends BundledLibKey>(key: K): Promise<Bu
 }
 
 /**
- * Returns a desktop-only bundled module (PTY companion, etc.) from the separate eval chunk.
+ * Returns a desktop-only bundled module (PTY companion, etc.) from the separate compressed chunk.
  */
 export async function getBundledDesktopLib<K extends BundledDesktopLibKey>(
   key: K


### PR DESCRIPTION
* ci: add build provenance attestation to release workflow
* refactor: extract shared bundled chunk runtime: Move duplicated eval logic and registry unwrapping into bundledChunkRuntime.ts for reuse across bundledInternals and bundledLibs.